### PR TITLE
[story/TP-101038] update dm-sql-finders to 3.2 and dependencies to our gems

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 ADAPTERS="mysql" # Use only these DM adapters
 # data_mapper, datamapper-do, dm-aggregates, dm-constraints, dm-core, dm-do-adapter, dm-migrations, dm-mysql-adapter, dm-noisy-failures,
 # dm-serializer, dm-timestamps, dm-transactions, dm-types, dm-validations"
-DM_DEV_INCLUDE="dm-core datamapper-do dm-aggregates dm-constraints dm-do-adapter dm-migrations dm-mysql-adapter dm-sqlite-adapter dm-noisy-failures dm-serializer dm-timestamps dm-transactions dm-types dm-validations"
+DM_DEV_INCLUDE="dm-core datamapper-do dm-aggregates dm-constraints dm-do-adapter dm-migrations dm-mysql-adapter dm-sqlite-adapter dm-noisy-failures dm-serializer dm-sql-finders dm-timestamps dm-transactions dm-types dm-validations"
 DM_DEV_EXCLUDE="dm-dev dm-tags dm-ar-finders"    # Makes sure that these gems are not used
 DM_DEV_GEMSET="datamapper"                         # With dm:gem:install, install all gems into the "datamapper" gemset
 DM_DEV_RUBIES="3.2.2"                      # The rvm ruby interpreters to use

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - ../dm-mysql-adapter:/home/$USER/datamapper/dm-mysql-adapter:delegated
       - ../dm-noisy-failures:/home/$USER/datamapper/dm-noisy-failures:delegated
       - ../dm-serializer:/home/$USER/datamapper/dm-serializer:delegated
+      - ../dm-sql-finders:/home/$USER/datamapper/dm-sql-finders:delegated
       - ../dm-sqlite-adapter:/home/$USER/datamapper/dm-sqlite-adapter:delegated
       - ../dm-timestamps:/home/$USER/datamapper/dm-timestamps:delegated
       - ../dm-transactions:/home/$USER/datamapper/dm-transactions:delegated


### PR DESCRIPTION
adding sql-finders to the docker-compose file

additional files to view:
https://github.com/firespring/data_mapper/pull/4
https://github.com/firespring/dm-aggregates/pull/6
https://github.com/firespring/dm-constraints/pull/6
https://github.com/firespring/dm-core/pull/6
https://github.com/firespring/dm-do-adapter/pull/7
https://github.com/firespring/dm-migrations/pull/6
https://github.com/firespring/dm-mysql-adapter/pull/7
https://github.com/firespring/dm-noisy-failures/pull/6
https://github.com/firespring/dm-serializer/pull/6
https://github.com/firespring/dm-sql-finders/pull/1
https://github.com/firespring/dm-sqlite-adapter/pull/4
https://github.com/firespring/dm-timestamps/pull/6
https://github.com/firespring/dm-transactions/pull/5
https://github.com/firespring/dm-types/pull/6
https://github.com/firespring/dm-validations/pull/6

To test run the rspec tests in the dm-sql-finders directory using `bundle exec rspec`. All of the tests should be passing.
